### PR TITLE
Configurable exclusions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fork of [nitrolabs/meteor-cdn](https://github.com/nitrolabs/meteor-cdn/) with tw
 with [mup-cloud-front](https://github.com/zodern/mup-cloud-front):
 
 - Appends `CDN_URL` with a deployment version if available
-- Does not use the CDN for css files. [See below](#configure-exclusions) how to configure
+- Does not use the CDN for css files by default. [See below](#configure-exclusions) how to configure
 
 Following that this was forked from [zodern/meteor-cdn](https://github.com/zodern/meteor-cdn) which has removed the
 Blaze helper.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Fork of [nitrolabs/meteor-cdn](https://github.com/nitrolabs/meteor-cdn/) with tw
 with [mup-cloud-front](https://github.com/zodern/mup-cloud-front):
 
 - Appends `CDN_URL` with a deployment version if available
-- Does not use the CDN for css files.
+- Does not use the CDN for css files. [See below](#configure-exclusions) how to configure
 
 Following that this was forked from [zodern/meteor-cdn](https://github.com/zodern/meteor-cdn) which has removed the
 Blaze helper.
@@ -41,6 +41,37 @@ CDN exposes function which can be used to get current CDN address.
 
 ```javascript
 CDN.get_cdn_url()
+```
+
+### Configure exclusions
+
+By default, files with the `.css` extension are not served via the CDN. The behaviour was required
+by `mup-cloud-front`, which this package was modified to support. More on that in the `mup-cloud-front`
+[readme](https://github.com/zodern/mup-cloud-front#why).
+
+Also, some project may not have any css files at all, i.e. when using `styled-components`.
+
+To enable serving files having the `.css` extension, use a configuration like this:
+
+```js
+// Cancel all exclusions
+CDN.config({
+  assets: {
+    excludeExtensions: false
+    // alternative option
+    // excludeExtensions: []
+  }
+})
+```
+
+You may decide to exclude other file extensions instead. You can do it like this:
+```js
+// Custom exclusions
+CDN.config({
+  assets: {
+    excludeExtensions: ['js']
+  }
+})
 ```
 
 ### Modifying headers to allow caching of public files

--- a/lib/server.js
+++ b/lib/server.js
@@ -43,6 +43,7 @@ function appendVersion (cdnUrl) {
 function CdnController () {
   let cdnUrl = appendVersion(stripSlashes(process.env.CDN_URL))
   let rootUrl = stripSlashes(process.env.ROOT_URL)
+  let excludedExtensions = ['.css']
 
   this._setRootUrl = function (newRootUrl) {
     // Change the ROOT_URL, for testing purposes
@@ -53,6 +54,28 @@ function CdnController () {
     // Change the CDN Url, for testing purposes
     cdnUrl = appendVersion(stripSlashes(newCdnUrl))
     setClientCdnUrl(cdnUrl)
+  }
+
+  this._configureExclusions = function (config) {
+    const setExclusions = (extensions = ['.css']) => {
+      excludedExtensions = extensions
+          .map(ext => `${ext.trim()}`.toLowerCase())
+          .map(ext => (ext.startsWith('.') ? ext : '.' + ext))
+    }
+
+    if (config && config.assets) {
+      const { excludeExtensions } = config.assets
+      if (excludeExtensions === false) {
+        setExclusions([])
+      } else if (typeof excludeExtensions === 'string' && excludeExtensions.length > 0) {
+        setExclusions([excludeExtensions])
+      } else if (Array.isArray(excludeExtensions) && excludeExtensions.every(ext => typeof ext === 'string')) {
+        setExclusions(excludeExtensions)
+      } else {
+        // i.e. excludeExtensions: true / excludeExtensions: ['.css', false] / excludeExtensions: { css: true }
+        throw new Error('Unexpected value in config.assets.excludeExtensions')
+      }
+    }
   }
 
   function validateSettings (rootUrl, cdnUrl) {
@@ -89,9 +112,9 @@ function CdnController () {
 
   const hasQuestionMark = new RegExp('[\?]')
   function processAssetPath (cdnUrl, assetPath) {
-    // Do not use cdn for css files
+    // Do not use cdn for files with excluded extensions
     const ext = path.extname(url.parse(assetPath).pathname)
-    if (ext === '.css') {
+    if (excludedExtensions.includes(ext)) {
       return assetPath
     }
 
@@ -211,6 +234,8 @@ CDN.config = function (config) {
       next()
     })
   }
+
+  CDN._configureExclusions(config)
 }
 
 // Add this for testing purposes

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,8 @@ import path from 'path'
 import { Meteor } from 'meteor/meteor'
 import { WebApp, WebAppInternals } from 'meteor/webapp'
 
+const rawHandlers = WebApp.rawHandlers || WebApp.rawExpressHandlers || WebApp.rawConnectHandlers
+
 const FONTS = ['.ttf', '.eot', '.otf', '.svg', '.woff', '.woff2']
 const ALLOWED_PROTOCOLS = ['http:', 'https:']
 
@@ -160,13 +162,8 @@ function CdnController () {
   if (validateSettings(rootUrl, cdnUrl)) {
     setClientCdnUrl(cdnUrl)
     configureBrowserPolicy(cdnUrl)
-    if (WebApp.rawExpressHandlers) {
-      WebApp.rawExpressHandlers.use(static404connectHandler)
-      WebApp.rawExpressHandlers.use(CORSConnectHandler)
-    } else {
-      WebApp.rawConnectHandlers.use(static404connectHandler)
-      WebApp.rawConnectHandlers.use(CORSConnectHandler)
-    }
+    rawHandlers.use(static404connectHandler)
+    rawHandlers.use(CORSConnectHandler)
     console.info('Using CDN: ' + cdnUrl)
   }
 
@@ -190,8 +187,7 @@ CDN.get_cdn_url = function () {
 // override headers for certain folders or files.
 CDN.config = function (config) {
   if (config.headers) {
-    // TODO: Meteor 3 migration to new handlers
-    WebApp.rawConnectHandlers.use('/', function (req, res, next) {
+    rawHandlers.use('/', function (req, res, next) {
       for (let path in config.headers) {
         if (config.headers.hasOwnProperty(path)) {
           // If path matches, setup headers for the response

--- a/lib/server.js
+++ b/lib/server.js
@@ -87,27 +87,32 @@ function CdnController () {
     return true
   }
 
-  function setClientCdnUrl (cdnUrl) {
-    // Make the CDN_URL available on the client
-    // console.log("Setting BundledJsCssPrefix to "+cdnUrl);
-    const hasQuestionMark = new RegExp('[\?]')
-    WebAppInternals.setBundledJsCssUrlRewriteHook(function (url) {
-      // Do not use cdn for css files
-      if (url.indexOf('.css') > -1) {
-        return url
-      }
+  const hasQuestionMark = new RegExp('[\?]')
+  function processAssetPath (cdnUrl, assetPath) {
+    // Do not use cdn for css files
+    if (assetPath.indexOf('.css') > -1) {
+      return assetPath
+    }
 
-      // This code fixes an issue in Galaxy where you can end up getting served
-      // stale code after deployments
-      const galaxyVersionId = process.env.GALAXY_APP_VERSION_ID
-      let rewrittenUrl = cdnUrl + url
-      if (galaxyVersionId) {
-        const separator = hasQuestionMark.test(url) ? '&' : '?'
-        rewrittenUrl += separator + '_g_app_v_=' + galaxyVersionId
-      }
-      return rewrittenUrl
+    // This code fixes an issue in Galaxy where you can end up getting served
+    // stale code after deployments
+    const galaxyVersionId = process.env.GALAXY_APP_VERSION_ID
+    let rewrittenUrl = cdnUrl + assetPath
+    if (galaxyVersionId) {
+      const separator = hasQuestionMark.test(assetPath) ? '&' : '?'
+      rewrittenUrl += separator + '_g_app_v_=' + galaxyVersionId
+    }
+    return rewrittenUrl
+  }
+
+  function setClientCdnUrl (cdnUrl) {
+    // console.log("Setting BundledJsCssPrefix to "+cdnUrl);
+    WebAppInternals.setBundledJsCssUrlRewriteHook(function (assetPath) {
+      return processAssetPath (cdnUrl, assetPath)
     })
     // WebAppInternals.setBundledJsCssPrefix(cdnUrl)
+
+    // Make the CDN_URL available on the client
     __meteor_runtime_config__.CDN_URL = cdnUrl
   }
 
@@ -170,6 +175,7 @@ function CdnController () {
   // TODO: Find a way to avoid this
   // Export for testing
   this._validateSettings = validateSettings
+  this._processAssetPath = processAssetPath
   this._CORSConnectHandler = CORSConnectHandler
   this._static404connectHandler = static404connectHandler
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -90,7 +90,8 @@ function CdnController () {
   const hasQuestionMark = new RegExp('[\?]')
   function processAssetPath (cdnUrl, assetPath) {
     // Do not use cdn for css files
-    if (assetPath.indexOf('.css') > -1) {
+    const ext = path.extname(url.parse(assetPath).pathname)
+    if (ext === '.css') {
       return assetPath
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,8 +1,7 @@
+import url from 'url'
+import path from 'path'
 import { Meteor } from 'meteor/meteor'
 import { WebApp, WebAppInternals } from 'meteor/webapp'
-
-const url = Npm.require('url')
-const path = Npm.require('path')
 
 const FONTS = ['.ttf', '.eot', '.otf', '.svg', '.woff', '.woff2']
 const ALLOWED_PROTOCOLS = ['http:', 'https:']

--- a/package.js
+++ b/package.js
@@ -19,6 +19,7 @@ Package.onUse(function (api) {
 
 Package.onTest(function (api) {
   api.use('tinytest')
+  api.use('ecmascript')
   api.use('storyteller:cdn')
   api.addFiles('tests/client.js', 'client')
   api.addFiles('tests/server.js', 'server')

--- a/tests/server.js
+++ b/tests/server.js
@@ -1,5 +1,4 @@
-var url = Npm.require("url");
-var path = Npm.require("path");
+import url from 'url';
 
 
 CONTROLLER = new CDN._controllerClass();

--- a/tests/server.js
+++ b/tests/server.js
@@ -372,4 +372,36 @@ Tinytest.add(
 
 
 
+// Scenario: CSS file is requested
+// CSS files should not be processed by the CDN module
+Tinytest.add(
+    'Server Side - CSS Files - By default NOT served from CDN',
+    function (test) {
+        var cdn = "http://www.cloudfront.com/";
+        var root = "http://www.meteor.com/";
+        var style = "packages/test-in-browser/driver.css";
 
+        CONTROLLER._setRootUrl(root);
+        CONTROLLER._setCdnUrl(cdn);
+
+        // Simulate request for the CSS file
+        var cssUrl = root + style;
+        req.url = cssUrl;
+        req.headers.host = url.parse(root).host;
+        res.headers = {};
+
+        CONTROLLER._static404connectHandler(req, res, next);
+
+        // Check that the CSS file exists and is served from the ROOT URL
+        test.equal(req.url, cssUrl, "CSS file should be served from ROOT URL");
+        test.equal(res.status, 200, "Expecting a 200 response for CSS file from ROOT URL");
+
+        // Check that the CSS url is NOT rewritten by the CDN
+        var assetPath = "/" + style;
+        var cdnProcessedUrl = CONTROLLER._processAssetPath(cdn, assetPath);
+        test.equal(cdnProcessedUrl, assetPath, 'Expecting the CDN controller to return the CSS file path');
+        test.notEqual(cdnProcessedUrl, cdn + assetPath, 'Expecting the CSS file URL to not be equal to CDN URL + CSS file path');
+
+        resetState();
+    }
+);

--- a/tests/server.js
+++ b/tests/server.js
@@ -257,7 +257,8 @@ Tinytest.add(
     var status;
     var cdn = "https://www.cloudfront.com/";
     var root = "http://www.meteor.com/";
-    var staticUrl = cdn + "packages/underscore.js";
+    // use a package that's most likely installed
+    var staticUrl = cdn + "packages/tinytest.js";
 
     CONTROLLER._setRootUrl(root)
     CONTROLLER._setCdnUrl(cdn);


### PR DESCRIPTION
By default, the CDN does not serve files with the `.css` extension. So we made it a configurable option, and added a few more tests to ensure the new settings work as intended and without breaking anything.

Some refactoring was needed, see individual commits for details.

Tested on a live [illustreets](https://illustreets.com/) instance which we use internally.

More background on how this pull request came about, in this [Meteor Forums thread](https://forums.meteor.com/t/large-saas-migrated-to-3-0/61113/7).