### PR TITLE
Fix "TypeError: CDN._configureExclusions is not a function"

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,7 @@ const rawHandlers = WebApp.rawHandlers || WebApp.rawExpressHandlers || WebApp.ra
 
 const FONTS = ['.ttf', '.eot', '.otf', '.svg', '.woff', '.woff2']
 const ALLOWED_PROTOCOLS = ['http:', 'https:']
+let excludedExtensions = ['.css']
 
 /* stripSlashes
  *
@@ -34,6 +35,32 @@ function appendVersion (cdnUrl) {
   return cdnUrl
 }
 
+/**
+ * Configures which file extensions are excluded from the CDN,
+ * i.e. css, js or none
+ */
+function configureExclusions (config) {
+  const setExclusions = (extensions = ['.css']) => {
+    excludedExtensions = extensions
+        .map(ext => `${ext.trim()}`.toLowerCase())
+        .map(ext => (ext.startsWith('.') ? ext : '.' + ext))
+  }
+
+  if (config && config.assets) {
+    const { excludeExtensions } = config.assets
+    if (excludeExtensions === false) {
+      setExclusions([])
+    } else if (typeof excludeExtensions === 'string' && excludeExtensions.length > 0) {
+      setExclusions([excludeExtensions])
+    } else if (Array.isArray(excludeExtensions) && excludeExtensions.every(ext => typeof ext === 'string')) {
+      setExclusions(excludeExtensions)
+    } else {
+      // i.e. excludeExtensions: true / excludeExtensions: ['.css', false] / excludeExtensions: { css: true }
+      throw new Error('Unexpected value in config.assets.excludeExtensions')
+    }
+  }
+}
+
 /* CdnController
  *
  * Controls the way that the CDN package interacts
@@ -43,7 +70,6 @@ function appendVersion (cdnUrl) {
 function CdnController () {
   let cdnUrl = appendVersion(stripSlashes(process.env.CDN_URL))
   let rootUrl = stripSlashes(process.env.ROOT_URL)
-  let excludedExtensions = ['.css']
 
   this._setRootUrl = function (newRootUrl) {
     // Change the ROOT_URL, for testing purposes
@@ -54,28 +80,6 @@ function CdnController () {
     // Change the CDN Url, for testing purposes
     cdnUrl = appendVersion(stripSlashes(newCdnUrl))
     setClientCdnUrl(cdnUrl)
-  }
-
-  this._configureExclusions = function (config) {
-    const setExclusions = (extensions = ['.css']) => {
-      excludedExtensions = extensions
-          .map(ext => `${ext.trim()}`.toLowerCase())
-          .map(ext => (ext.startsWith('.') ? ext : '.' + ext))
-    }
-
-    if (config && config.assets) {
-      const { excludeExtensions } = config.assets
-      if (excludeExtensions === false) {
-        setExclusions([])
-      } else if (typeof excludeExtensions === 'string' && excludeExtensions.length > 0) {
-        setExclusions([excludeExtensions])
-      } else if (Array.isArray(excludeExtensions) && excludeExtensions.every(ext => typeof ext === 'string')) {
-        setExclusions(excludeExtensions)
-      } else {
-        // i.e. excludeExtensions: true / excludeExtensions: ['.css', false] / excludeExtensions: { css: true }
-        throw new Error('Unexpected value in config.assets.excludeExtensions')
-      }
-    }
   }
 
   function validateSettings (rootUrl, cdnUrl) {
@@ -202,6 +206,7 @@ function CdnController () {
   this._processAssetPath = processAssetPath
   this._CORSConnectHandler = CORSConnectHandler
   this._static404connectHandler = static404connectHandler
+  this._configureExclusions = configureExclusions
 }
 
 // Export the CDN object
@@ -235,7 +240,7 @@ CDN.config = function (config) {
     })
   }
 
-  CDN._configureExclusions(config)
+  configureExclusions(config)
 }
 
 // Add this for testing purposes


### PR DESCRIPTION
Test are set in a peculiar way, which let this error slip through but it surfaces in production. 
So, I refactored the `CdnController` module and pulled out the `_configureExclusions` function as a standalone helper, which, in retrospect, I should have done from the start.